### PR TITLE
Add daemon_reload to mongodb systemd configuration

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 - name: Restart MongoDB
   systemd:
     name: mongod
+    daemon_reload: true
     state: restarted
   become: true
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 - name: Enable MongoDB service
   systemd:
     name: mongod
-    enabled: true
     daemon_reload: true
+    enabled: true
   become: true
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,5 +57,6 @@
   systemd:
     name: mongod
     enabled: true
+    daemon_reload: true
   become: true
   become_user: root


### PR DESCRIPTION
This was necessary to avoid errors that were appearing on my installation. This fix was suggested here: https://github.com/Stouts/Stouts.mongodb/issues/36