### PR TITLE
Install MongoDB 4.4 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ubuntu 18.04+.
 
 | parameter               | required | default            | comments                                                                |
 | ----------------------- | -------- | ------------------ | ----------------------------------------------------------------------- |
-| `mongodb_version`       | no       | `4.2`              | The major.minor version of MongoDB to install.                          |
+| `mongodb_version`       | no       | `4.4`              | The major.minor version of MongoDB to install.                          |
 | `mongodb_data_path`     | no       | `/var/lib/mongodb` | The filesystem path where data files will be persisted.                 |
 | `mongodb_bind_public`   | no       | `false`            | Whether to bind to all network interfaces. **This is a security risk.** |
 | `mongodb_authorization` | no       | `false`            | Whether to enable access control. Users must be created separately.     |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mongodb_version: "4.2"
+mongodb_version: "4.4"
 mongodb_data_path: "/var/lib/mongodb"
 mongodb_bind_public: false
 mongodb_authorization: false

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -4,7 +4,7 @@ import os
 def test_mongodb_install(host):
     mongodb_package = host.package('mongodb-org-server')
     assert mongodb_package.is_installed
-    assert mongodb_package.version.startswith('4.2')
+    assert mongodb_package.version.startswith('4.4')
 
 
 def test_mongodb_user(host):


### PR DESCRIPTION
This version supports Ubuntu 18.04 and 20.04.